### PR TITLE
Use recreate over recreateAndCopyValidProperties

### DIFF
--- a/ruby/optimizer/RubyIlFastpather.cpp
+++ b/ruby/optimizer/RubyIlFastpather.cpp
@@ -342,7 +342,7 @@ Ruby::IlFastpather::fastpathPlusMinus(TR::TreeTop *tt, TR::Node *node, bool isPl
    gotoNode->setBranchDestination(Btail->getEntry());
 
    // Now change the original call node in Btail to be a load
-   node = TR::Node::recreateAndCopyValidProperties(node,  
+   node = TR::Node::recreate(node,  
       TR::Node::xloadOp(static_cast<TR_RubyFE*>(TR::comp()->fe())));
 
    node->setSymbolReference(tempResult);


### PR DESCRIPTION
Node::recreateAndCopyValidProperties is deprecated in favour of Node::recreate.

This change requires OMR version be372b6 or later.
