### PR TITLE
Fix OS X assembler

### DIFF
--- a/ruby/build/toolcfg/gnu/common.mk
+++ b/ruby/build/toolcfg/gnu/common.mk
@@ -38,10 +38,15 @@ DEPSUFF=.depend.mk
 # to compile .spp files
 #
 AR_PATH?=ar
-AS_PATH?=as
 SED_PATH?=sed
 M4_PATH?=m4
 PERL_PATH?=perl
+
+ifeq ($(OS),osx)
+    AS_PATH?=clang
+else
+    AS_PATH?=as
+endif
 
 # TODO - Redo GCC version logic that used to be here
 ifeq ($(C_COMPILER),gcc)


### PR DESCRIPTION
I incorrectly assumed as was the same as clang on OS X - despite them both identifying as clang, there are slight differences in their supported options.